### PR TITLE
Fix to allow BCC and CC headers

### DIFF
--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -223,7 +223,26 @@ class SmtpMailer extends Mailer {
 
         $this->mailer->ClearCustomHeaders();
         foreach( $headers as $header_name => $header_value ) {
-            $this->mailer->AddCustomHeader( $header_name.':'.$header_value );
+            if(strtolower($header_name) == 'bcc' || strtolower($header_name) == 'cc') {
+
+                $addresses = preg_split('/(,|;)/', $header_value);
+
+                switch (strtolower($header_name)) {
+                    case 'bcc':
+                        foreach($addresses as $address) {
+                            $this->mailer->addBCC($address);
+                        }
+                        break;
+                    case 'cc':
+                        foreach($addresses as $address) {
+                            $this->mailer->addCC($address);
+                        }
+                        break;
+                }
+
+            } else {
+                $this->mailer->AddCustomHeader( $header_name.':'.$header_value );
+            }
         }
 
     }


### PR DESCRIPTION
This fix allows the `Email.cc_all_emails_to` and `Email.bcc_all_emails_to` settings to work

https://docs.silverstripe.org/en/3.1/developer_guides/email/#redirecting-emails