### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php"                           : ">=5.3.0",
         "composer/installers"           : ">=1.0",
         "silverstripe/framework"        : "^3.0",
-        "silverstripe/cms"              : ">=3.0",
+        "silverstripe/cms"              : "^3.0",
         "phpmailer/phpmailer"           : "~5.2.23"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php"                           : ">=5.3.0",
         "composer/installers"           : ">=1.0",
-        "silverstripe/framework"        : ">=3.0",
+        "silverstripe/framework"        : "^3.0",
         "silverstripe/cms"              : ">=3.0",
         "phpmailer/phpmailer"           : "~5.2.23"
     },


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.