### PR TITLE
Do not try to automatically detect the availability of TLS if security is disabled

### DIFF
--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -80,6 +80,7 @@ class SmtpMailer extends Mailer {
             $this->mailer->Host = $conf->server;
             $this->mailer->Port = $conf->port;
             $this->mailer->SMTPSecure = $conf->secure;
+            if (empty($conf->secure)) $this->mailer->SMTPAutoTLS = false; //Do not try to automatically detect the availability of TLS if security is disabled.
             $this->mailer->SMTPAuth = $conf->authenticate;
             $this->mailer->SMTPDebug = $conf->debug;
             $this->mailer->SetLanguage($conf->lang);


### PR DESCRIPTION
This fixes an issue for me when I'm trying to make an SMTP connection to localhost. I guess that the localhost server is incorrectly advertising that it could handle TLS, but then it fails if PHPMailer actually uses TLS.